### PR TITLE
User could not start more than one process instance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+single-instance = "0.3.2"
 winapi = { version = "0.3", features = ["winuser"] }
 
 [target.'cfg(windows)'.build-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,12 @@
 //#![windows_subsystem = "windows"] // yeah I know this is a bit weird but it hides the console
 
+extern crate single_instance;
+
+use single_instance::SingleInstance;
+
 use std::mem::zeroed;
 use std::ffi::CString;
-use std::{thread, time};
+use std::{thread, time, process};
 
 use winapi::shared::windef::HWND;
 use winapi::um::winuser;
@@ -10,6 +14,12 @@ use winapi::shared::windef::RECT;
 
 fn main() 
 {
+
+    let instance = SingleInstance::new("TopCenterStart11").unwrap();
+    if !instance.is_single() {
+        process::exit(0x0100);
+    }
+    
     println!("Let's fix what Microsoft couldn't!");
 
     unsafe


### PR DESCRIPTION
Add feature to check only one process instance is running. related issue #3 