### PR TITLE
Update for 22H2

### DIFF
--- a/src/FlippedTaskbar11/Settings.cs
+++ b/src/FlippedTaskbar11/Settings.cs
@@ -1,10 +1,9 @@
 using Microsoft.Win32;
 using System.Reflection;
+using TopCenterStart11.TaskbarLogic;
 
 namespace TopCenterStart11
 {
-    using TopCenterStart11.TaskbarLogic;
-
     public partial class SettingsForm : Form
     {
         const string ENABLE_AUTOSTART = "Enable Autostart";

--- a/src/FlippedTaskbar11/Settings.cs
+++ b/src/FlippedTaskbar11/Settings.cs
@@ -1,9 +1,10 @@
 using Microsoft.Win32;
 using System.Reflection;
-using TopCenterStart11.TaskbarLogics;
 
 namespace TopCenterStart11
 {
+    using TopCenterStart11.TaskbarLogic;
+
     public partial class SettingsForm : Form
     {
         const string ENABLE_AUTOSTART = "Enable Autostart";

--- a/src/FlippedTaskbar11/TaskbarLogic/TaskbarAlignment.cs
+++ b/src/FlippedTaskbar11/TaskbarLogic/TaskbarAlignment.cs
@@ -1,0 +1,14 @@
+﻿namespace TopCenterStart11.TaskbarLogic;
+
+public enum TaskbarAlignment
+{
+    Unknown,
+
+    Left,
+
+    Top,
+
+    Right,
+
+    Bottom,
+}

--- a/src/FlippedTaskbar11/TaskbarLogic/TaskbarItem.cs
+++ b/src/FlippedTaskbar11/TaskbarLogic/TaskbarItem.cs
@@ -1,0 +1,35 @@
+﻿/*
+ * Credits to https://gist.github.com/emoacht
+ * https://gist.github.com/emoacht/bb6c0305e24a915e4e233005aad605d5
+ */
+
+namespace TopCenterStart11.TaskbarLogic;
+
+internal class TaskbarItem
+{
+    public string DeviceInstanceId { get; }
+    public IntPtr Handle { get; }
+    public bool IsPrimary { get; }
+    public TaskbarAlignment Alignment { get; }
+    public WIN32.RECT TaskbarRect { get; }
+    public WIN32.RECT MonitorRect { get; }
+    public WIN32.RECT WorkRect { get; }
+
+    public TaskbarItem(
+        string deviceInstanceId,
+        IntPtr handle,
+        bool isPrimary,
+        TaskbarAlignment alignment,
+        WIN32.RECT taskbarRect,
+        WIN32.RECT monitorRect,
+        WIN32.RECT workRect)
+    {
+        this.DeviceInstanceId = deviceInstanceId;
+        this.Handle = handle;
+        this.IsPrimary = isPrimary;
+        this.Alignment = alignment;
+        this.TaskbarRect = taskbarRect;
+        this.MonitorRect = monitorRect;
+        this.WorkRect = workRect;
+    }
+}

--- a/src/FlippedTaskbar11/TaskbarLogic/TaskbarManager.cs
+++ b/src/FlippedTaskbar11/TaskbarLogic/TaskbarManager.cs
@@ -1,13 +1,11 @@
-﻿using TopCenterStart11.TaskbarLogic;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
-using System.Diagnostics;
 
-namespace TopCenterStart11.TaskbarLogics
+using static TopCenterStart11.TaskbarLogic.WIN32;
+
+namespace TopCenterStart11.TaskbarLogic
 {
     internal class TaskbarManager
     {
@@ -20,9 +18,16 @@ namespace TopCenterStart11.TaskbarLogics
         public const string DESKTOP_SWITCHER_TITLE = "";
 
         public const string TASKBAR_CLASS = "Shell_TrayWnd";
+        public const string SECONDARY_TASKBAR_CLASS = "Shell_SecondaryTrayWnd";
 
         public const string POPUP_TITLE = "PopupHost";
         public const string POPUP_CLASS = "Xaml_WindowedPopupClass";
+
+        public const string SYSTRAY_OVERFLOW_CLASS = "TopLevelWindowForOverflowXamlIsland";
+
+        private const uint SPIF_SENDWININICHANGE = 2;
+        private const uint SPIF_UPDATEINIFILE = 1;
+        private const uint SPIF_CHANGE = SPIF_UPDATEINIFILE | SPIF_SENDWININICHANGE;
 
         public const int START_WIDTH = 666;
         public const int START_HEIGHT = 750;
@@ -32,16 +37,13 @@ namespace TopCenterStart11.TaskbarLogics
         private Config config;
 
         private IntPtr startHwnd;
-        private IntPtr thumbnailHwnd;
-        private IntPtr taskbarHwnd;
+        private IntPtr systrayOverflowHwnd;
+
+        private ArrayList thumbnailHwnds;
+        private ArrayList taskbars;
         private IntPtr switcherHwnd;
 
-        private WIN32.DEVMODE devmode;
-        private WIN32.RECT workingArea;
-        private WIN32.RECT originalWorkingArea;
-
-        private WIN32.RECT taskbarWindowRect;
-        private WIN32.RECT taskbarClientRect;
+        private DEVMODE devmode;
 
         private CancellationTokenSource cancellationTokenSource;
         private bool valid = true;
@@ -50,116 +52,283 @@ namespace TopCenterStart11.TaskbarLogics
         public TaskbarManager(Config config)
         {
             this.config = config;
-            cancellationTokenSource = new CancellationTokenSource();
+            this.cancellationTokenSource = new CancellationTokenSource();
 
             // pre-fetch windows on launch.
-            startHwnd = WIN32.FindWindowA(START_MENU_CLASS, START_MENU_TITLE);
-            thumbnailHwnd = WIN32.FindWindowA(THUMBNAIL_CLASS, null);
-            taskbarHwnd = WIN32.FindWindowA(TASKBAR_CLASS, null);
-            switcherHwnd = WIN32.FindWindowA(DESKTOP_SWITCHER_CLASS, DESKTOP_SWITCHER_TITLE);
+            this.startHwnd = FindWindowA(START_MENU_CLASS, START_MENU_TITLE);
+            
+            this.thumbnailHwnds = new ArrayList();
+
+            foreach (var thumbnailHwnd in EnumerateThumbnails())
+            {
+                this.thumbnailHwnds.Add(thumbnailHwnd);
+            }
+
+            this.systrayOverflowHwnd = FindWindowA(SYSTRAY_OVERFLOW_CLASS, null);
+
+            this.taskbars = new ArrayList();
+
+            foreach (var taskbarItem in EnumerateTaskbars())
+            {
+                this.taskbars.Add(taskbarItem);
+            }
+        
+            this.switcherHwnd = FindWindowA(DESKTOP_SWITCHER_CLASS, DESKTOP_SWITCHER_TITLE);
             // some of these are not persistent,
             // so they require polling (unfortunately)
             // these are stored class-wide anyway to prevent
             // constant re-allocation whatever
 
             // -1 is for ENUM_CURRENT_SETTINGS, -2 is for ENUM_REGISTRY_SETTINGS
-            WIN32.EnumDisplaySettings(null, -1, ref this.devmode);
+            EnumDisplaySettings(null, -1, ref this.devmode);
             // obviously we want current settings.
-
-            workingArea = new WIN32.RECT();
-
-            unsafe
-            {
-                var working = new WIN32.RECT();
-                var pointer = &working;
-                WIN32.SystemParametersInfo(WIN32.SPI_GETWORKAREA, 0, (IntPtr)pointer, 0);
-                workingArea = working;
-            }
-
-            // new™️ and improved™️ working area
-            workingArea.Top += 48;
-            workingArea.Bottom += 48;
-
-            WIN32.GetWindowRect(taskbarHwnd, out taskbarWindowRect);
-            WIN32.GetClientRect(taskbarHwnd, out taskbarClientRect);
         }
 
         public void StartTaskbarLoop()
         {
-            if (!valid)
-                throw new Exception("This taskbar manager has already started once. Please onstruct a new one to restart it.");
+            if (!this.valid)
+                throw new Exception("This taskbar manager has already started once. Please construct a new one to restart it.");
 
-            // set new working area
-            unsafe
+            foreach (TaskbarItem taskbar in this.taskbars)
             {
-                var working = workingArea;
-                var pointer = &working;
-                WIN32.SystemParametersInfo(WIN32.SPI_SETWORKAREA, 0, (IntPtr)pointer, 0x02);
-                workingArea = working;
+                // update taskbar's monitor working area
+                UpdateWorkingArea(
+                    taskbar,
+                    WorkingAreaShift.Down);
             }
 
-            _ = Task.Run(doTaskbarLoopAsync, cancellationTokenSource.Token);
-            _ = Task.Run(doWindowPlacementLoopAsync, cancellationTokenSource.Token);
+            _ = Task.Run(
+                this.doTaskbarLoopAsync,
+                this.cancellationTokenSource.Token);
+            _ = Task.Run(
+                this.doWindowPlacementLoopAsync,
+                this.cancellationTokenSource.Token);
 
-            valid = false;
+            this.valid = false;
         }
 
         public void StopTaskbarLoop()
         {
-            if (!stopped && !valid)
+            if (!this.stopped && !this.valid)
             {
                 try
                 {
-                    // refetch working area
-
-                    unsafe
+                    foreach (TaskbarItem taskbar in this.taskbars)
                     {
-                        var working = new WIN32.RECT();
-                        var pointer = &working;
-                        WIN32.SystemParametersInfo(WIN32.SPI_GETWORKAREA, 0, (IntPtr)pointer, 0);
-                        workingArea = working;
-                    }
+                        // update taskbar's monitor working area
+                        UpdateWorkingArea(
+                            taskbar,
+                            WorkingAreaShift.Up);
 
-                    // old™️ and unimproved™️ working area
-                    workingArea.Top -= 48;
-                    workingArea.Bottom -= 48;
-
-                    unsafe
-                    {
-                        var working = workingArea;
-                        var pointer = &working;
-                        WIN32.SystemParametersInfo(WIN32.SPI_SETWORKAREA, 0, (IntPtr)pointer, 0x02);
-                        workingArea = working;
+                        // update taskbar window
+                        UpdateWindow(taskbar.Handle);
                     }
-                    WIN32.UpdateWindow(taskbarHwnd);
 
                     this.cancellationTokenSource.Cancel();
                 }
                 finally
                 {
-                    restartExplorer();
+                    this.restartExplorer();
                 }
-                stopped = true;
+
+                this.stopped = true;
             }
+        }
+        
+        private static IEnumerable<TaskbarItem> EnumerateTaskbars()
+        {
+            var monitors = EnumerateMonitors().ToArray();
+            var taskbars = GetWindows(new[] { TASKBAR_CLASS, SECONDARY_TASKBAR_CLASS }, monitors.Length);
+
+            foreach (var (deviceName, deviceInstanceId) in monitors)
+            {
+                var taskbar = taskbars.FirstOrDefault(x => string.Equals(x.deviceName, deviceName, StringComparison.OrdinalIgnoreCase));
+                if (taskbar == default)
+                    continue;
+
+                var isPrimary = (taskbar.className == SECONDARY_TASKBAR_CLASS);
+
+                var alignment = GetTaskbarAlignment(taskbar.monitorRect, taskbar.windowRect);
+                if (alignment == default)
+                    continue;
+
+                yield return new TaskbarItem(
+                    deviceInstanceId,
+                    taskbar.handle,
+                    isPrimary,
+                    alignment,
+                    taskbarRect: taskbar.windowRect,
+                    monitorRect: taskbar.monitorRect,
+                    workRect: taskbar.workRect);
+            }
+        }
+
+        private static IEnumerable<IntPtr> EnumerateThumbnails()
+        {
+            var monitors = EnumerateMonitors()
+                .ToArray();
+
+            var thumbnailHwnd = FindWindowEx(
+                IntPtr.Zero,
+                IntPtr.Zero,
+                THUMBNAIL_CLASS,
+                null);
+            
+            do
+            {
+                yield return thumbnailHwnd;
+
+                thumbnailHwnd = FindWindowEx(
+                    IntPtr.Zero,
+                    thumbnailHwnd,
+                    THUMBNAIL_CLASS,
+                    null);
+            }
+            while (thumbnailHwnd != IntPtr.Zero);
+        }
+
+        private static IEnumerable<(string deviceName, string deviceInstanceId)> EnumerateMonitors()
+        {
+            var size = (uint)Marshal.SizeOf<DISPLAY_DEVICE>();
+            var display = new DISPLAY_DEVICE { cb = size };
+            var monitor = new DISPLAY_DEVICE { cb = size };
+
+            for (uint i = 0; EnumDisplayDevices(null, i, ref display, EDD_GET_DEVICE_INTERFACE_NAME); i++)
+            {
+                if (display.StateFlags.HasFlag(DISPLAY_DEVICE_FLAG.DISPLAY_DEVICE_MIRRORING_DRIVER))
+                    continue;
+
+                for (uint j = 0; EnumDisplayDevices(display.DeviceName, j, ref monitor, EDD_GET_DEVICE_INTERFACE_NAME); j++)
+                {
+                    if (!monitor.StateFlags.HasFlag(DISPLAY_DEVICE_FLAG.DISPLAY_DEVICE_ACTIVE))
+                        continue;
+
+                    yield return (display.DeviceName, ConvertDeviceInstanceId(monitor.DeviceID));
+                }
+            }
+        }
+
+        private static (IntPtr handle, string className, RECT windowRect, string deviceName, RECT monitorRect, RECT workRect)[] GetWindows(string[] classNames, int count)
+        {
+            var windows = new List<(IntPtr, string, RECT, string, RECT, RECT)>();
+
+            if (EnumWindows(
+                    Proc,
+                    IntPtr.Zero))
+            {
+                return windows.ToArray();
+            }
+            return Array.Empty<(IntPtr, string, RECT, string, RECT, RECT)>();
+
+            bool Proc(IntPtr windowHandle, IntPtr _lParam)
+            {
+                var buffer = new StringBuilder(256);
+
+                if (GetClassName(
+                        windowHandle,
+                        buffer,
+                        buffer.Capacity) > 0)
+                {
+                    var className = buffer.ToString();
+                    if (classNames.Contains(className))
+                    {
+                        if (GetWindowRect(
+                                windowHandle,
+                                out RECT windowRect))
+                        {
+                            var monitorHandle = MonitorFromWindow(
+                                windowHandle,
+                                MONITOR_DEFAULTTO.MONITOR_DEFAULTTONULL);
+                            if (monitorHandle != IntPtr.Zero)
+                            {
+                                var monitorInfo = new MONITORINFOEX { cbSize = (uint)Marshal.SizeOf<MONITORINFOEX>() };
+
+                                if (GetMonitorInfo(
+                                        monitorHandle,
+                                        ref monitorInfo))
+                                {
+                                    windows.Add((windowHandle, className, windowRect, monitorInfo.szDevice, monitorInfo.rcMonitor, monitorInfo.rcWork));
+                                    if (windows.Count > count)
+                                        return false;
+                                }
+                            }
+                        }
+                    }
+                }
+                return true;
+            }
+        }
+
+        private static string ConvertDeviceInstanceId(string devicePath)
+        {
+            int index = devicePath.IndexOf("DISPLAY", StringComparison.Ordinal);
+            if (index < 0)
+                return null;
+
+            var fields = devicePath.Substring(index).Split('#');
+            if (fields.Length < 3)
+                return null;
+
+            return string.Join(@"\", fields.Take(3));
+        }
+
+        private static TaskbarAlignment GetTaskbarAlignment(RECT monitorRect, RECT taskbarRect)
+        {
+            return (left: (monitorRect.Left == taskbarRect.Left),
+                       top: (monitorRect.Top == taskbarRect.Top),
+                       right: (monitorRect.Right == taskbarRect.Right),
+                       bottom: (monitorRect.Bottom == taskbarRect.Bottom)) switch
+                {
+                    (true, true, right: false, true) => TaskbarAlignment.Left,
+                    (true, true, true, bottom: false) => TaskbarAlignment.Top,
+                    (left: false, true, true, true) => TaskbarAlignment.Right,
+                    (true, top: false, true, true) => TaskbarAlignment.Bottom,
+                    _ => default
+                };
+        }
+    
+        private void UpdateWorkingArea(TaskbarItem taskbar, WorkingAreaShift shiftDirection)
+        {
+            var taskbarWorkRect = taskbar.WorkRect;
+
+            switch (shiftDirection)
+            {
+                case WorkingAreaShift.Down:
+                    taskbarWorkRect.Top = TASKBAR_HEIGHT;
+                    taskbarWorkRect.Bottom = taskbar.MonitorRect.Bottom;
+                    break;
+                case WorkingAreaShift.Up:
+                    taskbarWorkRect.Top = taskbar.MonitorRect.Top;
+                    taskbarWorkRect.Bottom = taskbar.MonitorRect.Bottom - TASKBAR_HEIGHT;
+                    break;
+            }
+        
+            SystemParametersInfo(SPI_SETWORKAREA, 0, ref taskbarWorkRect, 0);
         }
 
         private async Task doTaskbarLoopAsync()
         {
             do
             {
-                // update taskbar window
-                WIN32.UpdateWindow(taskbarHwnd);
-                // Set new position for taskbar
-                WIN32.SetWindowPos(taskbarHwnd, IntPtr.Parse("-1"), taskbarWindowRect.Left, 0,
-                    taskbarWindowRect.Right, taskbarClientRect.Bottom, 0x0400);
+                foreach (TaskbarItem taskbar in this.taskbars)
+                {
+                    // update taskbar window
+                    UpdateWindow(taskbar.Handle);
+                
+                    // Set new position for taskbar
+                    SetWindowPos(taskbar.Handle, IntPtr.Parse("-1"),
+                        taskbar.TaskbarRect.Left, 0,
+                        taskbar.TaskbarRect.Width,
+                        taskbar.TaskbarRect.Height, 0x0400);
 
-                // Update taskbar
-                WIN32.UpdateWindow(taskbarHwnd);
-
-                if(config.PollingRate > 0)
-                    await Task.Delay(config.PollingRate);
+                    // update taskbar window
+                    UpdateWindow(taskbar.Handle);
+                }
+                
+                if(this.config.PollingRate > 0)
+                    await Task.Delay(this.config.PollingRate);
             } 
-            while (!cancellationTokenSource.IsCancellationRequested);
+            while (!this.cancellationTokenSource.IsCancellationRequested);
         }
 
         private async Task doWindowPlacementLoopAsync()
@@ -167,49 +336,56 @@ namespace TopCenterStart11.TaskbarLogics
             do
             {
                 // switcher is not persistent
-                switcherHwnd = WIN32.FindWindowA(DESKTOP_SWITCHER_CLASS, DESKTOP_SWITCHER_TITLE);
-                if (switcherHwnd != IntPtr.Zero)
-                    placeUnderTaskbar(switcherHwnd);
+                this.switcherHwnd = FindWindowA(DESKTOP_SWITCHER_CLASS, DESKTOP_SWITCHER_TITLE);
+                if (this.switcherHwnd != IntPtr.Zero) this.placeUnderTaskbar(this.switcherHwnd);
 
-                placeUnderTaskbar(thumbnailHwnd);
-                placeStart(startHwnd);
+                foreach (var thumbnailHwnd in this.thumbnailHwnds)
+                {
+                    this.placeUnderTaskbar((IntPtr)thumbnailHwnd);
+                }
 
-                if (config.PollingRate > 0)
-                    await Task.Delay(config.PollingRate);
+                this.startHwnd = FindWindowA(START_MENU_CLASS, START_MENU_TITLE);
+                if (this.startHwnd != IntPtr.Zero) this.placeStart(this.startHwnd);
+
+                this.systrayOverflowHwnd = FindWindowA(SYSTRAY_OVERFLOW_CLASS, null);
+                if (this.systrayOverflowHwnd != IntPtr.Zero) this.placeUnderTaskbar(this.systrayOverflowHwnd);
+
+                if (this.config.PollingRate > 0)
+                    await Task.Delay(this.config.PollingRate);
             }
-            while (!cancellationTokenSource.IsCancellationRequested);
+            while (!this.cancellationTokenSource.IsCancellationRequested);
         }
-
+    
         private void placeUnderTaskbar(IntPtr hwnd)
         {
-            WIN32.RECT windowRect;
-            WIN32.RECT clientRect;
-            WIN32.GetWindowRect(hwnd, out windowRect);
-            WIN32.GetClientRect(hwnd, out clientRect);
+            RECT windowRect;
+            RECT clientRect;
+            GetWindowRect(hwnd, out windowRect);
+            GetClientRect(hwnd, out clientRect);
 
             if(windowRect.Top != TASKBAR_HEIGHT)
             {
-                WIN32.SetWindowPos(hwnd, IntPtr.Zero, windowRect.Left, TASKBAR_HEIGHT, clientRect.Right, clientRect.Bottom, 0);
+                SetWindowPos(hwnd, IntPtr.Zero, windowRect.Left, TASKBAR_HEIGHT, clientRect.Right, clientRect.Bottom, 0);
             }
         }
 
         private void placeStart(IntPtr hwnd)
         {
-            var x_pos = (devmode.dmPelsWidth / 2) - (START_WIDTH / 2);
-            WIN32.SetWindowPos(hwnd, IntPtr.Zero, x_pos, TASKBAR_HEIGHT, START_WIDTH, START_HEIGHT, 0);
+            var x_pos = (this.devmode.dmPelsWidth / 2) - (START_WIDTH / 2);
+            SetWindowPos(hwnd, IntPtr.Zero, x_pos, TASKBAR_HEIGHT, START_WIDTH, START_HEIGHT, 0);
         }
 
         private void restartExplorer()
         {
             try
             {
-                var ptr = WIN32.FindWindowA(TASKBAR_CLASS, null);
+                var ptr = FindWindowA(TASKBAR_CLASS, null);
                 Console.WriteLine("INIT PTR: {0}", ptr.ToInt32());
-                WIN32.PostMessage(ptr, WIN32.WM_USER + 436, (IntPtr)0, (IntPtr)0);
+                PostMessage(ptr, WM_USER + 436, (IntPtr)0, (IntPtr)0);
 
                 do
                 {
-                    ptr = WIN32.FindWindowA(TASKBAR_CLASS, null);
+                    ptr = FindWindowA(TASKBAR_CLASS, null);
                     Console.WriteLine("PTR: {0}", ptr.ToInt32());
 
                     if (ptr.ToInt32() == 0)

--- a/src/FlippedTaskbar11/TaskbarLogic/Win32.cs
+++ b/src/FlippedTaskbar11/TaskbarLogic/Win32.cs
@@ -4,12 +4,8 @@
  
  */
 
-using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.InteropServices;
 using System.Text;
-using System.Threading.Tasks;
 
 namespace TopCenterStart11.TaskbarLogic
 {
@@ -24,6 +20,14 @@ namespace TopCenterStart11.TaskbarLogic
         [DllImport("user32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool SystemParametersInfo(uint uiAction, uint uiParam, IntPtr pvParam, uint fWinIni);
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool SystemParametersInfo(
+            uint uiAction,
+            uint uiParam,
+            ref RECT pvParam,
+            uint fWinIni);
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool GetWindowRect(IntPtr hwnd, out RECT lpRect);
@@ -44,6 +48,145 @@ namespace TopCenterStart11.TaskbarLogic
 
         [DllImport("user32.dll", SetLastError = true)]
         public static extern bool PostMessage(IntPtr hWnd, [MarshalAs(UnmanagedType.U4)] uint Msg, IntPtr wParam, IntPtr lParam);
+        
+        [DllImport("User32.dll", SetLastError = true)]
+        public static extern IntPtr FindWindowEx(
+            IntPtr hwndParent,
+            IntPtr hwndChildAfter,
+            string lpszClass,
+            string lpszWindow);
+
+        [DllImport("User32.dll", EntryPoint = "EnumDisplayDevicesA")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumDisplayDevices(
+            string lpDevice,
+            uint iDevNum,
+            ref DISPLAY_DEVICE lpDisplayDevice,
+            uint dwFlags);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+        public struct DISPLAY_DEVICE
+        {
+            public uint cb;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string DeviceName;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string DeviceString;
+
+            public DISPLAY_DEVICE_FLAG StateFlags;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string DeviceID;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 128)]
+            public string DeviceKey;
+        }
+
+        [Flags]
+        public enum DISPLAY_DEVICE_FLAG : uint
+        {
+            DISPLAY_DEVICE_ATTACHED_TO_DESKTOP = 0x00000001,
+            DISPLAY_DEVICE_MULTI_DRIVER = 0x00000002,
+            DISPLAY_DEVICE_PRIMARY_DEVICE = 0x00000004,
+            DISPLAY_DEVICE_MIRRORING_DRIVER = 0x00000008,
+            DISPLAY_DEVICE_VGA_COMPATIBLE = 0x00000010,
+            DISPLAY_DEVICE_REMOVABLE = 0x00000020,
+            DISPLAY_DEVICE_ACC_DRIVER = 0x00000040,
+            DISPLAY_DEVICE_RDPUDD = 0x01000000,
+            DISPLAY_DEVICE_DISCONNECT = 0x02000000,
+            DISPLAY_DEVICE_REMOTE = 0x04000000,
+            DISPLAY_DEVICE_MODESPRUNED = 0x08000000,
+
+            DISPLAY_DEVICE_ACTIVE = 0x00000001,
+            DISPLAY_DEVICE_ATTACHED = 0x00000002,
+        }
+
+        internal const uint EDD_GET_DEVICE_INTERFACE_NAME = 0x00000001;
+
+        [DllImport("User32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public extern static bool EnumWindows(
+            EnumWindowsProc lpEnumFun,
+            IntPtr lparam);
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public delegate bool EnumWindowsProc(
+            IntPtr hWnd,
+            IntPtr lParam);
+
+        [DllImport("User32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern int GetClassName(
+            IntPtr hWnd,
+            StringBuilder lpClassName,
+            int nMaxCount);
+        
+        [DllImport("User32.dll", SetLastError = true)]
+        public static extern IntPtr MonitorFromWindow(
+            IntPtr hWnd,
+            MONITOR_DEFAULTTO dwFlags);
+
+        public enum MONITOR_DEFAULTTO : uint
+        {
+            /// <summary>
+            /// If no display monitor intersects, returns null.
+            /// </summary>
+            MONITOR_DEFAULTTONULL = 0x00000000,
+
+            /// <summary>
+            /// If no display monitor intersects, returns a handle to the primary display monitor.
+            /// </summary>
+            MONITOR_DEFAULTTOPRIMARY = 0x00000001,
+
+            /// <summary>
+            /// If no display monitor intersects, returns a handle to the display monitor that is nearest to the rectangle.
+            /// </summary>
+            MONITOR_DEFAULTTONEAREST = 0x00000002,
+        }
+
+        [DllImport("User32.dll", EntryPoint = "GetMonitorInfoW")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool GetMonitorInfo(
+            IntPtr hMonitor,
+            ref MONITORINFOEX lpmi);
+
+        [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+        public struct MONITORINFOEX
+        {
+            public uint cbSize;
+            public RECT rcMonitor;
+            public RECT rcWork;
+            public uint dwFlags;
+
+            [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+            public string szDevice;
+        }
+
+        [return: MarshalAs(UnmanagedType.Bool)]
+        [DllImport("user32.dll",SetLastError = true)]
+        public static extern bool GetWindowInfo(IntPtr hwnd, ref WINDOWINFO pwi);
+
+        [StructLayout(LayoutKind.Sequential)]
+        public struct WINDOWINFO
+        {
+            public uint        cbSize;
+            public RECT        rcWindow;
+            public RECT        rcClient;
+            public uint        dwStyle;
+            public uint        dwExStyle;
+            public uint        dwWindowStatus;
+            public uint        cxWindowBorders;
+            public uint        cyWindowBorders;
+            public Int32       atomWindowType;
+            public Int32       wCreatorVersion;
+        }
+
+        [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+        public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+        public static extern int GetWindowTextLength(IntPtr hWnd);
 
         public const int WM_USER = 0x0400;
 
@@ -218,7 +361,7 @@ namespace TopCenterStart11.TaskbarLogic
         public const uint SPI_GETFONTSMOOTHINGORIENTATION = 0x2012;
         public const uint SPI_SETFONTSMOOTHINGORIENTATION = 0x2013;
         #endregion
-
+        
         #region DEVMODE
         [StructLayout(LayoutKind.Explicit, CharSet = CharSet.Ansi)]
         public struct DEVMODE
@@ -398,5 +541,8 @@ namespace TopCenterStart11.TaskbarLogic
             public int y;
         }
         #endregion
+
+        [DllImport("user32.dll", ExactSpelling = true, CharSet = CharSet.Auto)]
+        public static extern IntPtr GetParent(IntPtr hWnd);
     }
 }

--- a/src/FlippedTaskbar11/TaskbarLogic/WorkingAreaShift.cs
+++ b/src/FlippedTaskbar11/TaskbarLogic/WorkingAreaShift.cs
@@ -1,0 +1,8 @@
+﻿namespace TopCenterStart11.TaskbarLogic;
+
+public enum WorkingAreaShift
+{
+    Down,
+
+    Up,
+}


### PR DESCRIPTION
This is a first draft for a 22H2-compatible update. It works for multiple monitors and relocates the taskbar, the thumbnail on app icon mouseover and the systray.

The main issue I am still tackling with is the way to identify the start menu. It is done by an hard-coded title "start", but that fails in other languages (mine is french).
I was not able to retrieve a resource file containing this string, the actual `.exe` for the start menu is located here 
`C:\Windows\SystemApps\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\StartMenuExperienceHost.exe` 
and has a `.pri` resource file that I could not parse using `pinvoke`.

Problems/work still in progress:

- The taskbar has this "flickering" effect because it tries to reset back to its bottom position on mouseover or mouse click anywhere on it
- The contextual menu does not show (probably displaying over the screen top)
- The start menu is only repositioned in english UI version of Windows
- The systray settings window stays on the bottom of the screen. I have issues getting it by its classname because it is a generic one - `Windows.UI.Core.CoreWindow`. I tried to identify it by its process name - `c:\windows\systemapps\shellexperiencehost_cw5n1h2txyewy\shellexperiencehost.exe` - but no luck